### PR TITLE
Fix footer position on pages with little content

### DIFF
--- a/src/app/(protected)/archive/hikes/[id]/page.tsx
+++ b/src/app/(protected)/archive/hikes/[id]/page.tsx
@@ -25,7 +25,7 @@ export default function HikeDetailPage({ params }: { params: { id: string } }) {
   if (!hike) return null;
 
   return (
-    <main className="container mx-auto px-4 py-24">
+    <div className="container mx-auto px-4 py-24 flex-grow flex flex-col">
       <h1 className="text-4xl lg:text-5xl font-bold mb-8 text-center">{hike.name}</h1>
       
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">

--- a/src/app/(protected)/archive/hikes/page.tsx
+++ b/src/app/(protected)/archive/hikes/page.tsx
@@ -62,7 +62,7 @@ export default function HikesPage() {
   if (error) return <div className="container mx-auto px-4 py-24 text-center">Ошибка при загрузке походов.</div>;
 
   return (
-    <div className="container mx-auto px-4 py-24">
+    <div className="container mx-auto px-4 py-24 flex-grow flex flex-col">
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-3xl font-bold">Архив походов</h1>
         <div className="flex gap-4">

--- a/src/app/(protected)/archive/passes/[id]/page.tsx
+++ b/src/app/(protected)/archive/passes/[id]/page.tsx
@@ -50,7 +50,7 @@ export default function PassDetailPage({ params }: { params: { id: string } }) {
   if (!pass) return null;
 
   return (
-    <main className="container mx-auto px-4 py-24">
+    <div className="container mx-auto px-4 py-24 flex-grow flex flex-col">
       <h1 className="text-4xl lg:text-5xl font-bold mb-8 text-center">Перевал {pass.name}</h1>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">

--- a/src/app/(protected)/archive/passes/page.tsx
+++ b/src/app/(protected)/archive/passes/page.tsx
@@ -34,7 +34,7 @@ export default function PassesPage() {
   if (error) return <div>Ошибка при загрузке: {error.message}</div>;
 
   return (
-    <main className="container mx-auto px-4 py-24">
+    <div className="container mx-auto px-4 py-24 flex-grow flex flex-col">
       <h1 className="text-3xl font-bold mb-6">Каталог перевалов</h1>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {passes?.map((pass) => (

--- a/src/app/(protected)/articles/[slug]/page.tsx
+++ b/src/app/(protected)/articles/[slug]/page.tsx
@@ -29,11 +29,13 @@ export default function ArticleDetailPage({ params }: { params: { slug: string }
   if (error || !article) return <div>Статья не найдена.</div>;
 
   return (
-    <article>
-      <div className="mb-6 pb-4 border-b">
-        <p className="text-sm text-muted-foreground">Автор: {article.author}</p>
-      </div>
-      {article.content_html && <RichTextRenderer html={article.content_html} />}
-    </article>
+    <div className="max-w-4xl mx-auto py-24 px-4 flex-grow flex flex-col">
+      <article>
+        <div className="mb-6 pb-4 border-b">
+          <p className="text-sm text-muted-foreground">Автор: {article.author}</p>
+        </div>
+        {article.content_html && <RichTextRenderer html={article.content_html} />}
+      </article>
+    </div>
   );
 }

--- a/src/app/(protected)/articles/page.tsx
+++ b/src/app/(protected)/articles/page.tsx
@@ -21,7 +21,7 @@ export default function ArticlesPage() {
   if (error) return <div>Ошибка при загрузке статей: {error.message}</div>;
 
   return (
-    <div className="container mx-auto px-4 py-24">
+    <div className="container mx-auto px-4 py-24 flex-grow flex flex-col">
       <h1 className="text-3xl font-bold mb-6">Статьи</h1>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {articles?.map((item) => (

--- a/src/app/(protected)/profile/page.tsx
+++ b/src/app/(protected)/profile/page.tsx
@@ -278,7 +278,7 @@ export default function ProfilePage() {
   }
 
   return (
-    <div className="container mx-auto px-4 py-24">
+    <div className="container mx-auto px-4 py-24 flex-grow flex flex-col">
       <div className="flex justify-between items-center mb-8">
         <h1 className="text-3xl font-bold">Профиль пользователя</h1>
         <Button variant="destructive" onClick={handleLogout}>Выйти</Button>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,7 +33,7 @@ export default function RootLayout({
           <ModalProvider>
             <AuthProvider>
               <Header />
-              <main className="flex-grow">
+              <main className="flex-grow flex flex-col">
                 <Suspense fallback={<div>Загрузка...</div>}>
                   {children}
                 </Suspense>

--- a/src/app/news/[slug]/page.tsx
+++ b/src/app/news/[slug]/page.tsx
@@ -28,7 +28,7 @@ export default function NewsDetailPage({ params }: { params: { slug: string } })
   if (error || !newsItem) return <div>Новость не найдена.</div>;
 
   return (
-    <div className="max-w-4xl mx-auto py-24 px-4">
+    <div className="max-w-4xl mx-auto py-24 px-4 flex-grow flex flex-col">
       <article>
         {newsItem.content_html && <RichTextRenderer html={newsItem.content_html} />}
       </article>

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -21,7 +21,7 @@ export default function NewsPage() {
   if (error) return <div className="container mx-auto px-4 py-24 text-center">Не удалось загрузить новости.</div>;
 
   return (
-    <div className="container mx-auto px-4 py-24">
+    <div className="container mx-auto px-4 py-24 flex-grow flex flex-col">
       <h1 className="text-3xl font-bold mb-6">Новости</h1>
       {news && news.length > 0 ? (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">


### PR DESCRIPTION
On pages with little content, the footer was appearing too high on the page.

This was fixed by using a flexbox-based approach to create a "sticky footer" layout.

The main layout was updated to make the main content area a flex container that grows to fill the available space. Then, the `flex-grow` class was applied to the main content container on all relevant pages (hikes, passes, articles, news, and profile) to ensure the content area pushes the footer down.